### PR TITLE
Updated for Xcode 6

### DIFF
--- a/Classes/TSLibraryImport.h
+++ b/Classes/TSLibraryImport.h
@@ -30,9 +30,7 @@
 #define kTSUnknownError -65536
 #define kTSFileExistsError -48 //dupFNErr
 
-typedef NSInteger AVAssetExportSessionStatus;
-
-@class AVAssetExportSession;
+#import <AVFoundation/AVAssetExportSession.h>
 
 @interface TSLibraryImport : NSObject {
 	AVAssetExportSession* exportSession;
@@ -59,7 +57,7 @@ typedef NSInteger AVAssetExportSessionStatus;
 - (void)importAsset:(NSURL*)assetURL toURL:(NSURL*)destURL completionBlock:(void (^)(TSLibraryImport* import))completionBlock;
 
 @property (readonly) NSError* error;
-@property (readonly) AVAssetExportSessionStatus status;
+@property (readonly) enum AVAssetExportSessionStatus status;
 @property (readonly) float progress;
 
 @end


### PR DESCRIPTION
The forward declaration of the enum now leads to an ambiguous reference of AVAssetExportSessionStatus. I've rectified it by simply importing the AVAssetExportSession header.
